### PR TITLE
Group index table check API

### DIFF
--- a/lualib/smartsnmp/init.lua
+++ b/lualib/smartsnmp/init.lua
@@ -834,7 +834,7 @@ end
 -- print group index table through generator
 _M.group_index_table_check = function (group, name)
     local it = group_index_table_generator(group, name)
-
+    print(string.format("Group \'%s\' index table:", name))
     for i, v in ipairs(it) do
         if #v == 2 then
             print("scalar indexes:")


### PR DESCRIPTION
Signed-off-by: leo-ma begeekmyfriend@gmail.com

This debug API will print mib group index table information through generator checking whether it can be inquired correctly by snmp get/getnext command. The usage is as follows:

```
mib.group_index_table_check(group, 'name')
```

Single indexes:

```
Group 'ifGroup' index table:
scalar indexes:
Dim1:
1
Dim2:
0
table indexes:
Dim1:
2
Dim2:
1
Dim3:
1   2   3   4   5   6   7   8   9   10  16  22
Dim4:
1   2   3   4   5
```

Long indexes:

```
Group 'tcpGroup' index table:
scalar indexes:
Dim1:
1   2   3   4   5   6   7   8   9   10  11  12
Dim2:
0
table indexes:
Dim1:
13
Dim2:
1
Dim3:
1   2   3   4   5
Dim4:
0   0   0   0   22  0   0   0   0   0
10  2   12  229 33874   91  189 92  10  443
10  2   12  229 33875   91  189 92  23  443
10  2   12  229 37700   180 149 153 11  80
10  2   12  229 46149   180 149 134 54  80
10  2   12  229 53158   123 58  181 140 80
127 0   0   1   631 0   0   0   0   0
scalar indexes:
Dim1:
14  15
Dim2:
0
```

Cascaded indexes

```
Group 'ThreeIndexTable' index table:
table indexes:
Dim1:
1
Dim2:
1
Dim3:
1   2   3
Dim4:
1   3   5   7
Dim5:
2   3
Dim6:
32  87  123
```
