### PR TITLE
Transform physical address to octet string

### DIFF
--- a/lualib/smartsnmp/utils.lua
+++ b/lualib/smartsnmp/utils.lua
@@ -48,15 +48,39 @@ utils.getopt = function (arg, options)
   return tab
 end
 
-------------------------------------------------------------------------------
+-----------------------------------------
 -- convert oid string to oid lua table
-------------------------------------------------------------------------------
+-----------------------------------------
 utils.str2oid = function (s)
     local oid = {}
     for n in string.gmatch(s, '%d+') do
         table.insert(oid, tonumber(n))
     end
     return oid
+end
+
+local hexval = function(x)
+    if x >= string.byte('0') and x <= string.byte('9') then
+        return x - string.byte('0')
+    elseif x >= string.byte('a') and x <= string.byte('f') then
+        return x - string.byte('a') + 10
+    elseif x >= string.byte('A') and x <= string.byte('F') then
+        return x - string.byte('A') + 10
+    else
+        assert(0)
+    end
+end
+
+------------------------------------------
+-- convert physical address to string 
+------------------------------------------
+utils.mac2str = function(mac)
+    assert(type(mac) == 'string')
+    local s = {}
+    for i = 1, #mac, 2 do
+        table.insert(s, string.char(hexval(string.byte(mac, i)) * 16 + hexval(string.byte(mac, i + 1))))
+    end
+    return table.concat(s)
 end
 
 return utils

--- a/mibs/interfaces.lua
+++ b/mibs/interfaces.lua
@@ -18,6 +18,7 @@
 -- 
 
 local mib = require "smartsnmp"
+local utils = require "smartsnmp.utils"
 
 local if_entry_cache = {}
 
@@ -26,7 +27,7 @@ local entry = {
     type = 24,
     mtu = 65535,
     speed = 10000000,
-    phy_addr = 'aa0f163e7942',
+    phy_addr = utils.mac2str('aa0f163e7942'),
     admin_stat = 1,
     open_stat = 1,
     in_octet = 2449205,
@@ -40,7 +41,7 @@ entry = {
     type = 6,
     mtu = 1500,
     speed = 1000000,
-    phy_addr = '001f1633e721',
+    phy_addr = utils.mac2str('001f1633e721'),
     admin_stat = 1,
     open_stat = 1,
     in_octet = 672549159,
@@ -54,7 +55,7 @@ entry = {
     type = 6,
     mtu = 1500,
     speed = 100000000,
-    phy_addr = '8cae4cfe179c',
+    phy_addr = utils.mac2str('8cae4cfe179c'),
     admin_stat = 1,
     open_stat = 1,
     in_octet = 4914346,
@@ -68,7 +69,7 @@ entry = {
     type = 6,
     mtu = 1500,
     speed = 0,
-    phy_addr = '0026c6606030',
+    phy_addr = utils.mac2str('0026c6606030'),
     admin_stat = 2,
     open_stat = 2,
     in_octet = 0,
@@ -82,7 +83,7 @@ entry = {
     type = 6,
     mtu = 1500,
     speed = 0,
-    phy_addr = '160a8074ee77',
+    phy_addr = utils.mac2str('160a8074ee77'),
     admin_stat = 1,
     open_stat = 2,
     in_octet = 0,


### PR DESCRIPTION
Signed-off-by: leo-ma begeekmyfriend@gmail.com

New API for physical address to octet string transformation.
E.X. In `interface.lua`

```
local utils = require "smartsnmp.utils"

entry = {
    phyaddr = utils.utils.mac2str('001f1633e721'),
    ...
}
```

This movement will transform mac address into 6-byte octet string (such as "Hex String = 00 1f 16 33 e7 21").
