### PR TITLE
Support capture SIGINT and exit program peacefully.

### DIFF
--- a/core/agentx.c
+++ b/core/agentx.c
@@ -195,6 +195,7 @@ agentx_close(void)
     return -1;
   }
   
+  agentx_trans_ops.stop();
   return 0;
 }
 

--- a/core/agentx_tcp_evloop_transport.c
+++ b/core/agentx_tcp_evloop_transport.c
@@ -92,6 +92,13 @@ transport_running(void)
   snmp_event_run();
 }
 
+static void
+transport_stop(void)
+{
+  snmp_event_done();
+  close(agentx_entry.sock);
+}
+
 static int
 transport_init(int port)
 {
@@ -121,5 +128,6 @@ struct transport_operation agentx_trans_ops = {
   "agentx_tcp",
   transport_init,
   transport_running,
+  transport_stop,
   transport_send,
 };

--- a/core/snmp.c
+++ b/core/snmp.c
@@ -83,7 +83,7 @@ snmpd_open(void)
 static int
 snmpd_close(void)
 {
-  /* dummy */
+  snmp_trans_ops.stop();
   return 0;
 }
 

--- a/core/snmp_udp_evloop_transport.c
+++ b/core/snmp_udp_evloop_transport.c
@@ -95,6 +95,12 @@ transport_running(void)
   snmp_event_run();
 }
 
+static void
+transport_stop(void)
+{
+  snmp_event_done();
+}
+
 static int
 transport_init(int port)
 {
@@ -124,5 +130,6 @@ struct transport_operation snmp_trans_ops = {
   "snmp_udp",
   transport_init,
   transport_running,
+  transport_stop,
   transport_send,
 };

--- a/core/snmp_udp_libevent_transport.c
+++ b/core/snmp_udp_libevent_transport.c
@@ -131,7 +131,15 @@ transport_running(void)
   /* Enter the event loop; does not return. */
   event_base_dispatch(event_base);
 
+  event_base_free(event_base);
+
   close(sock);
+}
+
+static void
+transport_stop(void)
+{
+  event_base_loopexit(event_base, 0);
 }
 
 static int
@@ -166,5 +174,6 @@ struct transport_operation snmp_trans_ops = {
   "snmp_libevent",
   transport_init,
   transport_running,
+  transport_stop,
   transport_send,
 };

--- a/core/snmp_udp_uloop_transport.c
+++ b/core/snmp_udp_uloop_transport.c
@@ -94,6 +94,12 @@ transport_running(void)
 }
 
 static void
+transport_stop(void)
+{
+  uloop_done();
+}
+
+static void
 transport_init(int port)
 {
   struct sockaddr_in sin;
@@ -122,5 +128,6 @@ struct transport_operation snmp_trans_ops = {
   "snmp_uloop",
   transport_init,
   transport_running,
+  transport_stop,
   transport_send,
 };

--- a/core/transport.h
+++ b/core/transport.h
@@ -29,6 +29,7 @@ struct transport_operation {
   const char *name;
   int (*init)(int port);
   void (*running)(void);
+  void (*stop)(void);
   void (*send)(uint8_t *buf, int len);
 };
 

--- a/tests/smartsnmp_testframework.py
+++ b/tests/smartsnmp_testframework.py
@@ -209,7 +209,7 @@ class SmartSNMPTestFramework:
 		time.sleep(1)
 
 	def snmp_teardown(self):
-		self.snmp.close(force = True)
+		self.snmp.close()
 		time.sleep(1)
 
 	def agentx_setup(self, config_file):
@@ -222,6 +222,6 @@ class SmartSNMPTestFramework:
 		time.sleep(1)
 
 	def agentx_teardown(self):
-		self.agentx.close(force = True)
+		self.agentx.close()
 		self.netsnmp.close(force = True)
 		time.sleep(1)


### PR DESCRIPTION
Now, you can use `Ctrl-C` to interript the program.

- No need for setting `force=True` to close the agent when test.
- Add _stop_ method for transport then impl. them.
- Impl. _close_ for snmp and agentx.

Signed-off-by: Xiongfei Guo <xfguo@credosemi.com>