### PR TITLE
Fixbug: uloop_done() can't stop uloop loop, use uloop_end().

### DIFF
--- a/core/snmp_udp_uloop_transport.c
+++ b/core/snmp_udp_uloop_transport.c
@@ -96,7 +96,7 @@ transport_running(void)
 static void
 transport_stop(void)
 {
-  uloop_done();
+  uloop_end();
 }
 
 static void


### PR DESCRIPTION
Signed-off-by: Xiongfei Guo <xfguo@credosemi.com>